### PR TITLE
fix small error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # Installation
 
 ## Cloning the Repo
+
 Clone the repo by executing `git clone https://github.com/Alpisc/Selfbot`
 
 ## Installing dependencies
+
 Start the `Menu.bat` file and select the 3rd option by typing 3
 
 ## Setup
+
 Start the `Menu.bat` file and select the 2nd option by typing 2
 
 # Usage
 
 ## Start
-Start the `Menu.bat` file and select the nd option by typing 1
+
+Start the `Menu.bat` file and select the 1st option by typing 1
 
 # Extra
 
 ## Config
-If you need to reconfigure the config, either run `Menu.bat` or manually edit the config at `.config/config.json`
+
+If you need to reconfigure the config, either run `Menu.bat` or manually edit the config at `.content/config.json`


### PR DESCRIPTION
Fixed a minor error in the README.md file

in the ## Config it says that the directory is `.config` while it should instead be `.content`